### PR TITLE
Pull Requestリンクを取得するため修正

### DIFF
--- a/update_submodules.sh
+++ b/update_submodules.sh
@@ -1,23 +1,36 @@
 #!/bin/bash
-# GitHub CLI (gh) がインストール・gh auth login が実行されていることを前提とする
-# 実行時ブランチはmainブランチであることを前提とする
+# GitHub CLI (gh) がインストール・gh auth login が済んでいることが前提
+# 実行時ブランチはmainであることが前提
 
 echo "サブモジュールの更新"
 git submodule update --remote
 
-# 現在のブランチ名を取得
+echo "現在のブランチ名を取得"
 current_branch=$(git branch --show-current)
+
+# サブモジュールのリポジトリURLを取得する関数
+get_submodule_repo_url() {
+    local submodule_path=$1
+    local repo_url=$(git config --file .gitmodules --get-regexp "submodule\.$submodule_path\.url" | awk '{print $2}')
+    echo "$repo_url"
+}
 
 # サブモジュールの最新のクローズされたプルリクエストリンクを取得する関数
 get_submodule_latest_closed_pr_link() {
-    local repo=$1
-    local pr_link=$(gh pr list --repo "$repo" --state closed --sort updated --limit 1 --json url --jq '.[0].url')
+    local repo_url=$1
+    local repo_name=$(basename -s .git "$repo_url")
+    local repo_owner=$(basename $(dirname "$repo_url"))
+    local repo="$repo_owner/$repo_name"
+    local pr_link=$(gh pr list --repo "$repo" --state closed --sort created --limit 1 --json url --jq '.[0].url')
     if [ -z "$pr_link" ]; then
         echo "No closed pull request found for $repo"
     fi
     echo "$pr_link"
 }
 
+# サブモジュールのリポジトリURLを取得
+chrome_repo_url=$(get_submodule_repo_url "chrome_extensions")
+backend_repo_url=$(get_submodule_repo_url "errorda2_backend")
 
 # chrome_extensionsの最新コミットメッセージを取得
 chrome_commit_message=$(cd chrome_extensions && git log -1 --pretty=%B)
@@ -26,10 +39,9 @@ chrome_commit_message="submodule_chrome:$chrome_commit_message"
 # chromeの新しいブランチ名
 new_chrome_branch="dev-chrome_extensions-$(date +%Y%m%d%H)"
 # chromeのプルリクエストリンクを取得
-chrome_pr_link=$(get_submodule_latest_closed_pr_link "nachi739/errorda2_chrome_extensions")
+chrome_pr_link=$(get_submodule_latest_closed_pr_link "$chrome_repo_url")
 # chromeのPRの本文
 chrome_pr_body=$(echo -e "This PR updates the chrome_extensions submodule.\n\n## submodule-Pull-requests\n対象のサブモジュールのPull requestのリンク\n$chrome_pr_link")
-
 
 # --ここからchrome_extensionsの処理--
 echo "chrome_extensionsの変更をステージング(対象以外を含まないために)"
@@ -57,7 +69,6 @@ else
     echo "chrome_extensionsに変更はありません"
 fi
 
-
 # errorda2_backendの最新コミットメッセージを取得
 backend_commit_message=$(cd errorda2_backend && git log -1 --pretty=%B)
 # backendのコミットメッセージ内容
@@ -65,10 +76,9 @@ backend_commit_message="submodule_backend:$backend_commit_message"
 # backendの新しいブランチ名
 new_backend_branch="dev-errorda2_backend-$(date +%Y%m%d%H)"
 # backendのプルリクエストリンクを取得
-backend_pr_link=$(get_submodule_latest_closed_pr_link "nachi739/errorda2_backend")
+backend_pr_link=$(get_submodule_latest_closed_pr_link "$backend_repo_url")
 # backendのPRの本文
 backend_pr_body=$(echo -e "This PR updates the errorda2_backend submodule.\n\n## submodule-Pull-requests\n対象のサブモジュールのPull requestのリンク\n$backend_pr_link")
-
 
 # --ここからerrorda2_backendの処理--
 echo "errorda2_backendの変更をステージング(対象以外を含まないために)"


### PR DESCRIPTION
## やったこと

- .gitmodulesからサブモジュールのリポジトリURLを取得
- Pull requestリンクを取得する関数を修正

<br>

### なぜやるのか・背景（Optional）

- サブモジュールのPull requestリンクを取得できていないため
<br>

## やらないこと

- 動作確認・次回サブモジュール更新時に動作を確認する
<br>

## できるようになること（開発者目線）

- サブモジュールの更新でほぼ手動での作成が必要なくなる
<br>
