### PR TITLE
.vscodeの作成・管理対象外の更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,39 @@
-# Editor directories and files
-.vscode/*
-!.vscode/extensions.json
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/dist
+/dist-ssr
+
+# testing
+/coverage
+
+# production
+/build
+/package
+
+# vercel
+.vercel
+
+# next.js
+/.next/
+/out/
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# log files
+npm-debug.log*
+yarn-debug.log*
+pnpm-debug.log*
+yarn-error.log*
+lerna-debug.log*
+*.local
+logs
+*.log
+
+# misc
 .idea
 .DS_Store
 *.suo
@@ -8,3 +41,4 @@
 *.njsproj
 *.sln
 *.sw?
+*.pem

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "cSpell.words": ["Errorda", "nachi", "vercel", "notionhq"],
+  "window.title": "${dirty}${activeEditorShort}${separator}Errorda2"
+}


### PR DESCRIPTION
## やったこと

- .vscodeディレクトリの作成
- .gitignoreの管理対象外の内容更新
<br>

## なぜやるのか・背景
.vscode
- どのプロジェクトを開いているか確認しやすくするため
- 該当リポジトリでのスペルチェック対象外単語の登録

.gitignore
- .vscodeを管理するため
- 今まで初期設定で内容の確認を行えていなかったため
<br>

## 動作確認

- OS:Mac　ローカルで確認
- vscode上で反映されていることを確認

<br>

## Refs

- https://docs.github.com/ja/get-started/getting-started-with-git/ignoring-files
- https://www.toptal.com/developers/gitignore
<br>


