### PR TITLE
シェルスクリプトの修正・vscodeの設定追記

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "cSpell.words": ["Errorda", "nachi", "vercel", "notionhq"],
+  "cSpell.words": ["Errorda", "nachi", "vercel", "notionhq", "gitmodules"],
   "window.title": "${dirty}${activeEditorShort}${separator}Errorda2"
 }

--- a/update_submodules.sh
+++ b/update_submodules.sh
@@ -82,7 +82,7 @@ flag_commit_message=$(cd flag_checker && git log -1 --pretty=%B)
 # コミットメッセージ内容
 flag_commit_message="submodule_flag:$flag_commit_message"
 # 新しいブランチ名
-new_flag_branch="dev-errorda2_flag_checker-$(date +%Y%m%d%H)"
+new_flag_branch="dev-flag_checker-$(date +%Y%m%d%H)"
 # プルリクエストリンクを取得
 flag_pr_link=$(get_submodule_latest_closed_pr_link "$flag_repo_url")
 # PRの本文


### PR DESCRIPTION
## やったこと

- シェルスクリプトの修正
- vscodeの設定追記
<br>

## なぜやるのか・背景

- 表示される表示名を統一するため
- 意図しない警告マークを表示させないため
<br>

## 動作確認

- OS:Mac
- 次回サブモジュール更新時に確認する
- vscode上で反映されていることを確認
<br>


